### PR TITLE
BUGFIX: Break clausule added to for loop on SynchronousSocketListener

### DIFF
--- a/src/Sandbox/eocampo/EOPenServer/SynchronousSocketListener.cs
+++ b/src/Sandbox/eocampo/EOPenServer/SynchronousSocketListener.cs
@@ -23,8 +23,10 @@ namespace EOPenServer
             //IPAddress ipAddress = ipHostInfo.AddressList[0];
             IPAddress ipAddress = null;
             for (int i = 0; i < ipHostInfo.AddressList.LongLength; i++) {
-                if (ipHostInfo.AddressList[i].AddressFamily == AddressFamily.InterNetwork)
+                if (ipHostInfo.AddressList[i].AddressFamily == AddressFamily.InterNetwork) {
                     ipAddress = ipHostInfo.AddressList[i];
+                    break;
+                }
             }
             IPEndPoint localEndPoint = new IPEndPoint(ipAddress, 4510);
 


### PR DESCRIPTION
The for loop continues even when the correct Address is already found and assigned. To fix it we'll need to add a break to exit the loop.

- Fixes #3
